### PR TITLE
Add result_type to request.

### DIFF
--- a/src/GoogleMapsGeocoder.php
+++ b/src/GoogleMapsGeocoder.php
@@ -315,6 +315,12 @@
     private $signingKey;
 
     /**
+     *
+     * @var string
+     */
+    private $resultType;
+
+    /**
      * Constructor. The request is not executed until `geocode()` is called.
      *
      * @param  string $address optional address to geocode
@@ -722,7 +728,6 @@
     public function getApiKey() {
       return $this->apiKey;
     }
-
     /**
      * Set the client ID for Business clients.
      *
@@ -767,6 +772,20 @@
      */
     public function getSigningKey() {
       return $this->signingKey;
+    }
+
+    public function getResultType() {
+        return $this->resultType;
+    }
+
+    public function setResultType($resultType) {
+        if (is_array($resultType)) {
+            $this->resultType = implode('|', $resultType);
+        } else {
+            $this->resultType = $resultType;
+        }
+
+        return $this;
     }
 
     /**
@@ -823,6 +842,9 @@
       // Required.
       $queryString['sensor'] = $this->getSensor();
 
+      //Result type
+      $queryString['result_type'] = $this->getResultType();
+      
       // Remove any unset parameters.
       $queryString = array_filter($queryString);
 


### PR DESCRIPTION
One or more address types, separated by a pipe (|). Examples of address types: country, street_address, postal_code. Specifying a type will restrict the results to this type. If multiple types are specified, the API will return all addresses that match any of the types. Note: This parameter is available only for requests that include an API key or a client ID.
https://developers.google.com/maps/documentation/geocoding/#reverse-restricted