### PR TITLE
Added correct arg separator in http_build_query

### DIFF
--- a/src/GoogleMapsGeocoder.php
+++ b/src/GoogleMapsGeocoder.php
@@ -974,7 +974,7 @@
       }
 
       // Convert array to proper query string.
-      return http_build_query($queryString);
+      return http_build_query($queryString, null, '&');
     }
 
     /**


### PR DESCRIPTION
on some PHP servers is in default configuration `arg_separator.output = &amp;`
