### PR TITLE
Adding cURL as second transport method

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,5 +1,5 @@
 {
-    "name": "jstayton/google-maps-geocoder",
+    "name": "mindgruve/google-maps-geocoder",
     "type": "library",
     "description": "A PHP wrapper for the Google Maps Geocoding API v3.",
     "keywords": ["google", "map", "maps", "gmap", "gmaps", "geocode", "geocoder", "geocoding"],

--- a/src/GoogleMapsGeocoder.php
+++ b/src/GoogleMapsGeocoder.php
@@ -1052,7 +1052,7 @@
               return $result;
           }
 
-          file_get_contents($url, false, $streamContext);
+          return file_get_contents($url, false, $streamContext);
       }
 
     /**


### PR DESCRIPTION
On a client of ours, we needed allow_url_fopen to be turned off. (Issue #24 )
This PR adds the ability to use cURL if available on system, else falls back to file_get_contents.
